### PR TITLE
Correct remote base URL

### DIFF
--- a/doc/kustomize/README.md
+++ b/doc/kustomize/README.md
@@ -9,7 +9,7 @@ To create a custom deployment based on kustomize, first create an overlay with y
 
 	namespace: jitsi
 	bases:
-	- https://github.com/jitsi-contrib/jitsi-kubernetes/tree/main/doc/kustomize
+	- github.com/jitsi-contrib/jitsi-kubernetes/doc/kustomize
 	
 	resources:
 	- 041-ingress.yaml


### PR DESCRIPTION
Fixes #19

The format of remote bases and remote resources in kustomize has been changing recently and still isn't stable, but this PR changes it to one that's much more likely to work with recent versions of kubectl and kustomize.